### PR TITLE
Optimize computation of make_round_dicts

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -519,7 +519,7 @@ pub fn make_round_dicts(stds: [[f64; 5]; 5], odds: [[u8; 5]; 5]) -> RoundDictDat
         Box::new([const { MaybeUninit::uninit() }; 3124]);
 
     // SAFETY: All indices are in bounds, indices i0-i4 are in range [0, 5).
-    let round_data = ROUND_DATA.get_or_init(|| build_round_data());
+    let round_data = ROUND_DATA.get_or_init(build_round_data);
     unsafe {
         for chunk in 0..781 {
             let base = chunk * 4;

--- a/src/nfc.rs
+++ b/src/nfc.rs
@@ -398,13 +398,13 @@ impl NeoFoodClub {
     }
 
     /// Returns the maximum TER values we'll use.
-    pub fn max_ters(&self) -> &Vec<f64> {
+    pub fn max_ters(&self) -> &[f64] {
         let general = self.modifier.is_general();
         let data = self.round_dict_data();
 
         if let Some(bet_amount) = self.bet_amount {
             if general {
-                return &data.ers;
+                return &*data.ers;
             }
 
             // if there's a bet amount, we use Net Expected instead of Expected Return
@@ -427,7 +427,7 @@ impl NeoFoodClub {
             });
             new_ers
         } else {
-            &data.ers
+            &*data.ers
         }
     }
 
@@ -454,7 +454,7 @@ impl NeoFoodClub {
         let data = self.round_dict_data();
         let odds = &data.odds;
 
-        let mut indices = argsort_slice_3124(odds, |a: &u32, b: &u32| a.cmp(b));
+        let mut indices = argsort_slice_3124(&**odds, |a: &u32, b: &u32| a.cmp(b));
 
         if descending {
             indices.reverse();
@@ -470,7 +470,8 @@ impl NeoFoodClub {
         let data = self.round_dict_data();
         let probs = &data.probs;
 
-        let mut indices = argsort_slice_3124(probs, |a: &f64, b: &f64| a.partial_cmp(b).unwrap());
+        let mut indices =
+            argsort_slice_3124(&**probs, |a: &f64, b: &f64| a.partial_cmp(b).unwrap());
 
         if descending {
             indices.reverse();


### PR DESCRIPTION
Refactored RoundDictData to use fixed-size Boxed arrays for bins, probs, odds, ers, and maxbets, improving memory layout and access speed. Introduced precomputed ROUND_DATA for efficient index and binary calculation. Updated make_round_dicts to use unsafe and MaybeUninit for faster initialization. Adjusted nfc.rs to use slices instead of Vec for compatibility with new data structure.