### PR TITLE
perf: use integer ceiling division for maxbet

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -467,7 +467,7 @@ pub fn make_round_dicts(stds: [[f64; 5]; 5], odds: [[u8; 5]; 5]) -> RoundDictDat
                         );
 
                         let er = total_probs * total_odds as f64;
-                        let maxbet = (1_000_000.0 / total_odds as f64).ceil() as u32;
+                        let maxbet = (1_000_000u32 + total_odds - 1) / total_odds;
 
                         bins.push(total_bin);
                         probs.push(total_probs);

--- a/src/math.rs
+++ b/src/math.rs
@@ -467,7 +467,7 @@ pub fn make_round_dicts(stds: [[f64; 5]; 5], odds: [[u8; 5]; 5]) -> RoundDictDat
                         );
 
                         let er = total_probs * total_odds as f64;
-                        let maxbet = (1_000_000u32 + total_odds - 1) / total_odds;
+                        let maxbet = 1_000_000u32.div_ceil(total_odds);
 
                         bins.push(total_bin);
                         probs.push(total_probs);


### PR DESCRIPTION
The old `(1_000_000.0 / total_odds as f64).ceil() as u32` does two int-to-float conversions, a float divide, and a float-to-int cast for each of the 3124 entries in `make_round_dicts`; `1_000_000u32.div_ceil(total_odds)` is equivalent using pure integer arithmetic with no floating-point involvement.