### PR TITLE
ci: restrict push triggers to main branch only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Coverage
 
-on: [pull_request, push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Run Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- CI.yml, test.yml, coverage.yml were triggering on every branch push AND on pull_request
- This caused duplicate runs for every commit pushed to a PR branch
- Fix: add `branches: [main]` to all `push` triggers so PRs only run via `pull_request`
- codspeed.yml and renovate-automerge.yml were already correct, no changes needed

## Test plan

- [ ] Open a PR and push a commit -- confirm only one CI run fires (not two)
- [ ] Merge to main -- confirm all workflows still trigger