### PR TITLE
Fix wheel matrix: dedupe abi3 wheels per target instead of per Python version

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -17,6 +17,9 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  # The crate uses pyo3's stable ABI (abi3-py311), so one wheel per target
+  # covers every supported Python version - build with the floor version.
+  BUILD_PYTHON_VERSION: "3.11"
 
 jobs:
   macos:
@@ -24,7 +27,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: &python-versions ["3.11", "3.12", "3.13", "3.14"]
         target: [x86_64, universal2-apple-darwin]
     steps:
       - &checkout-step
@@ -44,20 +46,21 @@ jobs:
           grep -m1 '^version' crates/python/Cargo.toml
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - uses: astral-sh/setup-uv@v8.3.0
+      - &setup-uv-step
+        uses: astral-sh/setup-uv@v8.3.0
         with:
           enable-cache: false
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.BUILD_PYTHON_VERSION }}
       - name: "Build wheels - macOS"
         uses: PyO3/maturin-action@v1
         with:
           working-directory: crates/python
           target: ${{ matrix.target }}
-          args: --release -i python${{ matrix.python-version }} --out dist
+          args: --release -i python${{ env.BUILD_PYTHON_VERSION }} --out dist
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-macos-${{ matrix.target }}-${{ matrix.python-version }}
+          name: wheels-macos-${{ matrix.target }}
           path: crates/python/dist
 
   linux:
@@ -65,7 +68,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: *python-versions
         platform:
           - target: x86_64-unknown-linux-gnu
           - target: i686-unknown-linux-gnu
@@ -77,10 +79,7 @@ jobs:
     steps:
       - *checkout-step
       - *set-version-step
-      - uses: astral-sh/setup-uv@v8.3.0
-        with:
-          enable-cache: false
-          python-version: ${{ matrix.python-version }}
+      - *setup-uv-step
       - name: "Build wheels - Linux"
         uses: PyO3/maturin-action@v1
         with:
@@ -88,11 +87,11 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release -i python${{ matrix.python-version }} -o dist
+          args: --release -i python${{ env.BUILD_PYTHON_VERSION }} -o dist
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-linux-${{ matrix.python-version }}-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.target }}
           path: crates/python/dist
 
   musllinux:
@@ -100,7 +99,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: *python-versions
         platform:
           - target: x86_64-unknown-linux-musl
           - target: i686-unknown-linux-musl
@@ -110,10 +108,7 @@ jobs:
     steps:
       - *checkout-step
       - *set-version-step
-      - uses: astral-sh/setup-uv@v8.3.0
-        with:
-          enable-cache: false
-          python-version: ${{ matrix.python-version }}
+      - *setup-uv-step
       - name: "Build wheels - musllinux"
         uses: PyO3/maturin-action@v1
         with:
@@ -121,11 +116,11 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release -i python${{ matrix.python-version }} -o dist
+          args: --release -i python${{ env.BUILD_PYTHON_VERSION }} -o dist
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-musllinux-${{ matrix.python-version }}-${{ matrix.platform.target }}
+          name: wheels-musllinux-${{ matrix.platform.target }}
           path: crates/python/dist
 
   ci:


### PR DESCRIPTION
## Summary

The `v1.0.20` release job failed on the very first PyPI upload with `400 Invalid distribution file. ZIP archive not accepted: Trailing data` — nothing actually got published (confirmed: PyPI has no `1.0.20` for `neofoodclub`).

Root cause: `crates/python` uses pyo3's stable ABI (`abi3-py311`), so a wheel built once is valid for Python 3.11-3.14+. The matrix instead built every target at every Python version (3.11-3.14), producing 4 files with the *same* filename per target. The `release` job's `download-artifact ... merge-multiple: true` step flattens all 48 artifacts into one directory — when multiple artifacts contain a same-named file, GitHub's merge concatenates rather than overwrites, corrupting the wheel. PyPI's zip validation caught it.

Fix: drop the `python-version` matrix axis, build once per target with a fixed `python3.11` interpreter (the abi3 floor). Cuts the matrix from 48 jobs to 12.

## Test plan

- [x] YAML parses and anchors (`*checkout-step`, `*set-version-step`, new `*setup-uv-step`) resolve correctly (verified with pyyaml locally)
- [x] Matrix confirmed to produce unique artifact names per target now (no more `-${{ matrix.python-version }}` suffix collisions)
- [ ] Re-cut the `v1.0.20` release after this merges, confirm all 12 wheels upload cleanly this time