### PR TITLE
Add crates/wasm: WebAssembly bindings for the JS/TS frontend

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,3 +40,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "Clippy"
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+  wasm-build:
+    name: "wasm32 build check"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: "Install Rust toolchain"
+        run: |
+          rustup default nightly
+          rustup target add wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: "Build neofoodclub-wasm for wasm32-unknown-unknown"
+        run: cargo build -p neofoodclub-wasm --target wasm32-unknown-unknown --release

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --exclude neofoodclub-python --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --exclude neofoodclub-python --exclude neofoodclub-wasm --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Install Rust
         run: rustup default nightly
       - name: Build
-        run: cargo build --verbose --workspace --exclude neofoodclub-python
+        run: cargo build --verbose --workspace --exclude neofoodclub-python --exclude neofoodclub-wasm
       - name: Run tests
-        run: cargo test --verbose --workspace --exclude neofoodclub-python
+        run: cargo test --verbose --workspace --exclude neofoodclub-python --exclude neofoodclub-wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,17 +287,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -394,10 +420,12 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -460,6 +488,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "neofoodclub-wasm"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "neofoodclub",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +548,12 @@ checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -690,6 +735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +760,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -767,6 +829,12 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "statrs"
@@ -899,34 +967,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
-dependencies = [
- "bumpalo",
- "log",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
+ "rustversion",
+ "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -934,22 +990,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/core", "crates/python"]
+members = ["crates/core", "crates/python", "crates/wasm"]
 resolver = "2"
 
 [profile.release]

--- a/crates/core/src/nfc.rs
+++ b/crates/core/src/nfc.rs
@@ -47,6 +47,7 @@ pub struct NeoFoodClub {
     pub bet_amount: Option<u32>,
     pub modifier: Modifier,
     pub probability_model: ProbabilityModel,
+    custom_probabilities: Option<[[f64; 5]; 5]>,
     arenas: OnceCell<Arenas>,
     stds: OnceCell<[[f64; 5]; 5]>,
     data: OnceCell<RoundDictData>,
@@ -77,6 +78,7 @@ impl NeoFoodClub {
             bet_amount: None,
             modifier: use_modifier,
             probability_model: model.unwrap_or_default(),
+            custom_probabilities: None,
             arenas: OnceCell::new(),
             stds: OnceCell::new(),
             data: OnceCell::new(),
@@ -99,15 +101,34 @@ impl NeoFoodClub {
         self.clear_ranking_caches();
     }
 
+    /// Overrides the computed win probabilities with caller-supplied values,
+    /// bypassing the probability model entirely (used by "custom odds mode"
+    /// style callers who want to experiment with arbitrary probabilities that
+    /// don't correspond to any real odds/food data). Pass `None` to clear the
+    /// override and resume using the configured `probability_model`.
+    ///
+    /// This invalidates `round_dict_data()` and every ranking cache derived
+    /// from it, since those are computed from `probabilities()`.
+    pub fn set_custom_probabilities(&mut self, probabilities: Option<[[f64; 5]; 5]>) {
+        self.custom_probabilities = probabilities;
+        self.data = OnceCell::new();
+        self.clear_ranking_caches();
+    }
+
     /// Lazy loads the Arenas object.
     #[inline]
     pub fn get_arenas(&self) -> &Arenas {
         self.arenas.get_or_init(|| Arenas::new(&self.round_data))
     }
 
-    /// Lazy loads the probabilities.
+    /// Lazy loads the probabilities. Returns the custom override set via
+    /// `set_custom_probabilities`, if any, instead of computing via the
+    /// configured `probability_model`.
     #[inline]
     pub fn probabilities(&self) -> [[f64; 5]; 5] {
+        if let Some(custom) = self.custom_probabilities {
+            return custom;
+        }
         *self.stds.get_or_init(|| match self.probability_model {
             ProbabilityModel::OriginalModel => OriginalModel::new(&self.round_data),
             ProbabilityModel::MultinomialLogitModel => {

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -860,6 +860,36 @@ mod tests {
     }
 
     #[test]
+    fn test_custom_probabilities_override() {
+        let mut nfc = make_test_nfc();
+
+        let default_probs = nfc.probabilities();
+
+        // an arbitrary override, distinct from whatever the model computed
+        let custom = [
+            [1.0, 0.4, 0.3, 0.2, 0.1],
+            [1.0, 0.1, 0.2, 0.3, 0.4],
+            [1.0, 0.25, 0.25, 0.25, 0.25],
+            [1.0, 0.4, 0.3, 0.2, 0.1],
+            [1.0, 0.1, 0.2, 0.3, 0.4],
+        ];
+        nfc.set_custom_probabilities(Some(custom));
+
+        assert_eq!(nfc.probabilities(), custom);
+        assert_ne!(nfc.probabilities(), default_probs);
+
+        // round_dict_data (and everything derived from it, like the
+        // max-TER ranking) must reflect the override, not the model.
+        assert_eq!(nfc.round_dict_data().probs.len(), 3124);
+        let bets = nfc.make_max_ter_bets();
+        assert_eq!(bets.len(), 10);
+
+        // clearing the override falls back to the model's own computation.
+        nfc.set_custom_probabilities(None);
+        assert_eq!(nfc.probabilities(), default_probs);
+    }
+
+    #[test]
     fn test_max_ter_reverse() {
         let mut nfc = make_test_nfc_from_url();
 

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "neofoodclub-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+neofoodclub = { path = "../core" }
+wasm-bindgen = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+getrandom = { version = "0.4", features = ["wasm_js"] }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-bulk-memory"]

--- a/crates/wasm/src/engine.rs
+++ b/crates/wasm/src/engine.rs
@@ -1,0 +1,196 @@
+use std::collections::HashMap;
+
+use neofoodclub::bets::Bets;
+use neofoodclub::modifier::Modifier;
+use neofoodclub::nfc::{NeoFoodClub, ProbabilityModel};
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+#[derive(Serialize)]
+struct BetsOut {
+    indices: Vec<[u8; 5]>,
+    amounts: Option<Vec<Option<u32>>>,
+    #[serde(rename = "betsHash")]
+    bets_hash: String,
+    #[serde(rename = "amountsHash")]
+    amounts_hash: Option<String>,
+}
+
+impl From<Bets> for BetsOut {
+    fn from(bets: Bets) -> Self {
+        BetsOut {
+            indices: bets.get_indices(),
+            amounts: bets.bet_amounts.clone(),
+            bets_hash: bets.bets_hash(),
+            amounts_hash: bets.amounts_hash(),
+        }
+    }
+}
+
+fn to_js(bets: Bets) -> Result<JsValue, JsError> {
+    serde_wasm_bindgen::to_value(&BetsOut::from(bets)).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// A stateful wrapper around `NeoFoodClub`, meant to be constructed once per
+/// round-data update and reused across multiple bet-generation calls, so
+/// Rust's own caching (the 3124-combo table, max-TER rankings, etc.) isn't
+/// redone on every call.
+#[wasm_bindgen]
+pub struct NfcEngine {
+    inner: NeoFoodClub,
+}
+
+#[wasm_bindgen]
+impl NfcEngine {
+    /// Constructs a new engine from raw round JSON (the same camelCase shape
+    /// already used by `computeStdProbabilities`). `bet_amount` should
+    /// already be clamped by the caller (e.g. TS's `getMaxBet()`) before
+    /// being passed in.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        round_json: &str,
+        bet_amount: Option<u32>,
+        use_logit: bool,
+    ) -> Result<NfcEngine, JsError> {
+        let model = if use_logit {
+            ProbabilityModel::MultinomialLogitModel
+        } else {
+            ProbabilityModel::OriginalModel
+        };
+        let inner = NeoFoodClub::from_json(round_json, bet_amount, Some(model), None)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(NfcEngine { inner })
+    }
+
+    /// Re-seats the bet amount (max bet) without rebuilding the whole engine;
+    /// correctly invalidates just the ranking caches that depend on it.
+    #[wasm_bindgen(js_name = setBetAmount)]
+    pub fn set_bet_amount(&mut self, amount: Option<u32>) {
+        self.inner.set_bet_amount(amount);
+    }
+
+    /// Overrides odds for specific pirates (by global pirate ID, derived from
+    /// `odds_grid` + this engine's own round data). `odds_grid` is a
+    /// flattened 25-element array (5 arenas x [unused, o1..o4]), matching the
+    /// app's `OddsData` shape - already resolved to whatever the caller wants
+    /// to treat as "current" odds.
+    #[wasm_bindgen(js_name = setCustomOdds)]
+    pub fn set_custom_odds(&mut self, odds_grid: Vec<u8>) -> Result<(), JsError> {
+        if odds_grid.len() != 25 {
+            return Err(JsError::new(
+                "odds_grid must have exactly 25 elements (5 arenas x 5 slots)",
+            ));
+        }
+        let mut map: HashMap<u8, u8> = HashMap::new();
+        for arena in 0..5 {
+            for pirate_idx in 1..5 {
+                let pirate_id = self.inner.round_data.pirates[arena][pirate_idx - 1];
+                let odds = odds_grid[arena * 5 + pirate_idx];
+                map.insert(pirate_id, odds);
+            }
+        }
+        let modifier = Modifier::new(
+            self.inner.modifier.value,
+            Some(map),
+            self.inner.modifier.custom_time,
+        )
+        .map_err(|e| JsError::new(&e.to_string()))?;
+        self.inner
+            .with_modifier(modifier)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    /// Clears any custom-odds override set via `setCustomOdds`.
+    #[wasm_bindgen(js_name = clearCustomOdds)]
+    pub fn clear_custom_odds(&mut self) -> Result<(), JsError> {
+        let modifier = Modifier::new(
+            self.inner.modifier.value,
+            None,
+            self.inner.modifier.custom_time,
+        )
+        .map_err(|e| JsError::new(&e.to_string()))?;
+        self.inner
+            .with_modifier(modifier)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(())
+    }
+
+    /// Overrides win probabilities with caller-supplied values, bypassing the
+    /// probability model entirely. `probs_grid` is a flattened 25-element
+    /// array (5 arenas x [unused, p1..p4]).
+    #[wasm_bindgen(js_name = setCustomProbabilities)]
+    pub fn set_custom_probabilities(&mut self, probs_grid: Vec<f64>) -> Result<(), JsError> {
+        if probs_grid.len() != 25 {
+            return Err(JsError::new(
+                "probs_grid must have exactly 25 elements (5 arenas x 5 slots)",
+            ));
+        }
+        let mut probs = [[0.0; 5]; 5];
+        for arena in 0..5 {
+            for pirate in 0..5 {
+                probs[arena][pirate] = probs_grid[arena * 5 + pirate];
+            }
+        }
+        self.inner.set_custom_probabilities(Some(probs));
+        Ok(())
+    }
+
+    /// Clears any custom-probabilities override set via `setCustomProbabilities`.
+    #[wasm_bindgen(js_name = clearCustomProbabilities)]
+    pub fn clear_custom_probabilities(&mut self) {
+        self.inner.set_custom_probabilities(None);
+    }
+
+    #[wasm_bindgen(js_name = makeMaxTerBets)]
+    pub fn make_max_ter_bets(&self) -> Result<JsValue, JsError> {
+        to_js(self.inner.make_max_ter_bets())
+    }
+
+    #[wasm_bindgen(js_name = makeBestGambitBets)]
+    pub fn make_best_gambit_bets(&self) -> Result<JsValue, JsError> {
+        to_js(self.inner.make_best_gambit_bets())
+    }
+
+    /// `pirates_binary` must select exactly 5 pirates (one per arena) - the
+    /// core `make_gambit_bets` hard-asserts this, so we validate here first
+    /// rather than ever reaching that assert through the wasm boundary.
+    #[wasm_bindgen(js_name = makeGambitBets)]
+    pub fn make_gambit_bets(&self, pirates_binary: u32) -> Result<JsValue, JsError> {
+        if pirates_binary.count_ones() != 5 {
+            return Err(JsError::new(
+                "pirates_binary must select exactly 5 pirates (one per arena)",
+            ));
+        }
+        to_js(self.inner.make_gambit_bets(pirates_binary))
+    }
+
+    /// Returns `undefined` (via `null` -> caller should treat as no result)
+    /// when the round has no winners yet.
+    #[wasm_bindgen(js_name = makeWinningGambitBets)]
+    pub fn make_winning_gambit_bets(&self) -> Result<Option<JsValue>, JsError> {
+        self.inner.make_winning_gambit_bets().map(to_js).transpose()
+    }
+
+    /// Returns `null` when no arena is positive (bustproof isn't possible).
+    #[wasm_bindgen(js_name = makeBustproofBets)]
+    pub fn make_bustproof_bets(&self) -> Result<Option<JsValue>, JsError> {
+        self.inner.make_bustproof_bets().map(to_js).transpose()
+    }
+
+    #[wasm_bindgen(js_name = makeCrazyBets)]
+    pub fn make_crazy_bets(&self) -> Result<JsValue, JsError> {
+        to_js(self.inner.make_crazy_bets())
+    }
+
+    /// Errors if `pirates_binary` selects more than 1 pirate per arena, or
+    /// 0/more-than-3 pirates total.
+    #[wasm_bindgen(js_name = makeTenbetBets)]
+    pub fn make_tenbet_bets(&self, pirates_binary: u32) -> Result<JsValue, JsError> {
+        let bets = self
+            .inner
+            .make_tenbet_bets(pirates_binary)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        to_js(bets)
+    }
+}

--- a/crates/wasm/src/hash.rs
+++ b/crates/wasm/src/hash.rs
@@ -21,10 +21,7 @@ pub fn compute_bets_indices_to_hash(flat_indices: Vec<u8>) -> Result<String, JsE
     if !flat_indices.len().is_multiple_of(5) {
         return Err(JsError::new("length must be a multiple of 5"));
     }
-    let indices: Vec<[u8; 5]> = flat_indices
-        .chunks_exact(5)
-        .map(|c| [c[0], c[1], c[2], c[3], c[4]])
-        .collect();
+    let indices: Vec<[u8; 5]> = flat_indices.as_chunks::<5>().0.to_vec();
     Ok(math::bets_hash_value(indices))
 }
 

--- a/crates/wasm/src/hash.rs
+++ b/crates/wasm/src/hash.rs
@@ -1,0 +1,56 @@
+use neofoodclub::math;
+use wasm_bindgen::prelude::*;
+
+/// Replaces the internal `parseBets` used by `parseBetUrl`. Decodes a bets
+/// hash (`#b=...` fragment) into a flattened n*5 array of pirate indices (0-4
+/// per arena, 0 = no pick). Note: unlike the old TS decoder, an all-zero
+/// 5-tuple embedded between real bets is dropped (positions compact), and a
+/// malformed hash (containing bytes outside a-y) is a hard error rather than
+/// silently stripped - callers should catch and fall back to empty bets.
+#[wasm_bindgen(js_name = computeBetsHashToIndices)]
+pub fn compute_bets_hash_to_indices(bets_hash: &str) -> Result<Vec<u8>, JsError> {
+    let indices =
+        math::bets_hash_to_bet_indices(bets_hash).map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(indices.into_iter().flatten().collect())
+}
+
+/// Replaces the internal `makeBetsUrl`. Encodes a flattened n*5 array of
+/// pirate indices into a bets hash string.
+#[wasm_bindgen(js_name = computeBetsIndicesToHash)]
+pub fn compute_bets_indices_to_hash(flat_indices: Vec<u8>) -> Result<String, JsError> {
+    if !flat_indices.len().is_multiple_of(5) {
+        return Err(JsError::new("length must be a multiple of 5"));
+    }
+    let indices: Vec<[u8; 5]> = flat_indices
+        .chunks_exact(5)
+        .map(|c| [c[0], c[1], c[2], c[3], c[4]])
+        .collect();
+    Ok(math::bets_hash_value(indices))
+}
+
+/// Replaces the internal `parseBetAmounts`. Decodes an amounts hash (`#a=...`
+/// fragment) into one entry per bet. Rust models "no amount set" as `None`
+/// (any decoded value below `BET_AMOUNT_MIN`); that's represented here as
+/// `-1` so callers can map it to their own "unset" sentinel without needing
+/// an `Option`-aware boundary type.
+#[wasm_bindgen(js_name = computeAmountsHashToBetAmounts)]
+pub fn compute_amounts_hash_to_bet_amounts(amounts_hash: &str) -> Result<Vec<i64>, JsError> {
+    let amounts = math::amounts_hash_to_bet_amounts(amounts_hash)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(amounts
+        .into_iter()
+        .map(|a| a.map(|v| v as i64).unwrap_or(-1))
+        .collect())
+}
+
+/// Replaces the internal `makeBetAmountsUrl`. Encodes one amount per bet
+/// into an amounts hash string; any value `< 1` (including the `-1` "unset"
+/// sentinel from `computeAmountsHashToBetAmounts`) encodes as `None`.
+#[wasm_bindgen(js_name = computeBetAmountsToAmountsHash)]
+pub fn compute_bet_amounts_to_amounts_hash(amounts: Vec<i64>) -> String {
+    let opts: Vec<Option<u32>> = amounts
+        .into_iter()
+        .map(|v| if v >= 1 { Some(v as u32) } else { None })
+        .collect();
+    math::bet_amounts_to_amounts_hash(&opts)
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,0 +1,148 @@
+mod engine;
+mod hash;
+
+pub use engine::NfcEngine;
+pub use hash::*;
+
+use neofoodclub::math;
+use neofoodclub::nfc::{NeoFoodClub, ProbabilityModel};
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+/// Replaces the `std`/`used` portion of `computeLegacyProbabilities` (original
+/// model) or the `prob`/`used` portion of `computeLogitProbabilities` (logit
+/// model), depending on `use_logit`. `round_json` is the raw camelCase
+/// RoundData JSON as fetched from cdn.neofood.club/rounds/{round}.json - no
+/// field marshalling needed. Returns a flattened 25-element array (5 arenas x
+/// [unused, p1, p2, p3, p4]).
+#[wasm_bindgen(js_name = computeStdProbabilities)]
+pub fn compute_std_probabilities(round_json: &str, use_logit: bool) -> Result<Vec<f64>, JsError> {
+    let model = if use_logit {
+        ProbabilityModel::MultinomialLogitModel
+    } else {
+        ProbabilityModel::OriginalModel
+    };
+    let nfc = NeoFoodClub::from_json(round_json, None, Some(model), None)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(nfc.probabilities().into_iter().flatten().collect())
+}
+
+/// Replaces `calculateArenaRatios(customOdds)`. `odds` is a flattened
+/// 25-element array (5 arenas x [unused, o1, o2, o3, o4]), matching the app's
+/// `OddsData` shape - already resolved to either current or custom odds by
+/// the caller. Returns one ratio per arena.
+#[wasm_bindgen(js_name = computeArenaRatios)]
+pub fn compute_arena_ratios(odds: Vec<f64>) -> Result<Vec<f64>, JsError> {
+    if odds.len() != 25 {
+        return Err(JsError::new(
+            "odds must have exactly 25 elements (5 arenas x 5 slots)",
+        ));
+    }
+    let ratios = (0..5)
+        .map(|arena| {
+            let sum: f64 = (1..5).map(|pirate| 1.0 / odds[arena * 5 + pirate]).sum();
+            1.0 / sum - 1.0
+        })
+        .collect();
+    Ok(ratios)
+}
+
+#[derive(Serialize)]
+struct ChanceOut {
+    value: u32,
+    probability: f64,
+    cumulative: f64,
+    tail: f64,
+}
+
+impl From<neofoodclub::chance::Chance> for ChanceOut {
+    fn from(c: neofoodclub::chance::Chance) -> Self {
+        ChanceOut {
+            value: c.value,
+            probability: c.probability,
+            cumulative: c.cumulative,
+            tail: c.tail,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PayoutTablesOut {
+    odds: Vec<ChanceOut>,
+    winnings: Vec<ChanceOut>,
+}
+
+/// Replaces `calculatePayoutTables(bets, probabilities, betOdds, betPayoffs)`.
+/// `bet_indices` is a flattened n*5 array of pirate indices (0-4 per arena, 0
+/// = no pick), matching the existing `Bet = Map<number, number[]>` shape one
+/// bet at a time. `probabilities` is a flattened 25-element array (already
+/// resolved to legacy/logit/custom by the caller, matching `usedProbabilities`
+/// in the app). `bet_odds`/`bet_payoffs` are parallel n-length arrays. Returns
+/// `{ odds, winnings }` where each is an array of
+/// `{ value, probability, cumulative, tail }`.
+#[wasm_bindgen(js_name = computePayoutTables)]
+pub fn compute_payout_tables(
+    bet_indices: Vec<u8>,
+    probabilities: Vec<f64>,
+    bet_odds: Vec<u32>,
+    bet_payoffs: Vec<u32>,
+) -> Result<JsValue, JsError> {
+    if !bet_indices.len().is_multiple_of(5) {
+        return Err(JsError::new("bet_indices length must be a multiple of 5"));
+    }
+    let n = bet_indices.len() / 5;
+    if bet_odds.len() != n || bet_payoffs.len() != n {
+        return Err(JsError::new(
+            "bet_odds and bet_payoffs must have one entry per bet",
+        ));
+    }
+    if probabilities.len() != 25 {
+        return Err(JsError::new(
+            "probabilities must have exactly 25 elements (5 arenas x 5 slots)",
+        ));
+    }
+
+    let bets: Vec<[u8; 5]> = bet_indices
+        .chunks_exact(5)
+        .map(|chunk| [chunk[0], chunk[1], chunk[2], chunk[3], chunk[4]])
+        .collect();
+
+    let mut probs = [[0.0; 5]; 5];
+    for arena in 0..5 {
+        for pirate in 0..5 {
+            probs[arena][pirate] = probabilities[arena * 5 + pirate];
+        }
+    }
+
+    let odds_table = math::build_chance_objects(&bets, &bet_odds, probs);
+    let winnings_table = math::build_chance_objects(&bets, &bet_payoffs, probs);
+
+    let out = PayoutTablesOut {
+        odds: odds_table.into_iter().map(ChanceOut::from).collect(),
+        winnings: winnings_table.into_iter().map(ChanceOut::from).collect(),
+    };
+
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Replaces `computePirateBinary(arenaIndex, pirateIndex)`. Note the argument
+/// order is swapped relative to `neofoodclub::math::pirate_binary(index, arena)`.
+#[wasm_bindgen(js_name = computePirateBinary)]
+pub fn compute_pirate_binary(arena_index: u8, pirate_index: u8) -> u32 {
+    math::pirate_binary(pirate_index, arena_index)
+}
+
+/// Replaces `computePiratesBinary`. `pirates` must have exactly 5 elements.
+#[wasm_bindgen(js_name = computePiratesBinary)]
+pub fn compute_pirates_binary(pirates: Vec<u8>) -> Result<u32, JsError> {
+    let indices: [u8; 5] = pirates
+        .try_into()
+        .map_err(|_| JsError::new("expected exactly 5 elements"))?;
+    Ok(math::pirates_binary(indices))
+}
+
+/// Replaces `computeBinaryToPirates`.
+#[wasm_bindgen(js_name = computeBinaryToPirates)]
+pub fn compute_binary_to_pirates(bin: u32) -> Vec<u8> {
+    math::binary_to_indices(bin).to_vec()
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -102,10 +102,7 @@ pub fn compute_payout_tables(
         ));
     }
 
-    let bets: Vec<[u8; 5]> = bet_indices
-        .chunks_exact(5)
-        .map(|chunk| [chunk[0], chunk[1], chunk[2], chunk[3], chunk[4]])
-        .collect();
+    let bets: Vec<[u8; 5]> = bet_indices.as_chunks::<5>().0.to_vec();
 
     let mut probs = [[0.0; 5]; 5];
     for arena in 0..5 {


### PR DESCRIPTION
## Summary
- Adds a new `crates/wasm` workspace member exposing a wasm-bindgen binding of the engine, joining `crates/core`/`crates/python` per #175's own stated goal ("groundwork for a future JS/TS binding to join as another workspace member")
- Moves the 6 pure-math wasm functions (`computeStdProbabilities`, `computeArenaRatios`, `computePayoutTables`, `computePirateBinary`/`computePiratesBinary`/`computeBinaryToPirates`) here from the frontend's previously-vendored copy, so they live in the canonical repo
- Adds `NfcEngine`, a stateful wasm wrapper around `NeoFoodClub` meant to be constructed once per round update and reused across bet-generation calls (reusing Rust's own caching instead of redoing the 3124-combo table every call): `makeMaxTerBets`, `makeBestGambitBets`, `makeGambitBets`, `makeWinningGambitBets`, `makeBustproofBets`, `makeCrazyBets`, `makeTenbetBets`, plus `setBetAmount`/`setCustomOdds`/`setCustomProbabilities` and their clear/counterparts
- Adds a `custom_probabilities` override to `NeoFoodClub` itself (`crates/core/src/nfc.rs`) - lets a caller bypass the probability model with arbitrary probabilities, needed for the frontend's "custom odds mode." Every generator reads probabilities only through `probabilities()`/`round_dict_data()`, so this flows through with zero changes to `bets_factory.rs`
- Adds four new hash codec bindings (`computeBetsHashToIndices`/`computeBetsIndicesToHash`/`computeAmountsHashToBetAmounts`/`computeBetAmountsToAmountsHash`) wrapping the existing `math.rs` codecs - none of these were exposed to wasm before
- CI: excludes `neofoodclub-wasm` from native build/test/coverage (same reasoning as the existing `neofoodclub-python` exclusion - a cdylib can't usefully build/test on the native target), adds a dedicated `wasm-build` job that actually compiles for `wasm32-unknown-unknown`

## Design notes
- Methods wrapping a core call that can panic on user-influenced input (`make_gambit_bets`'s 5-bit-popcount assert) pre-validate and return a JS error instead - a panic here would trap the whole long-lived `NfcEngine` instance for the rest of a session, not just one throwaway call like it would have under a stateless design
- No `[profile.release]` in `crates/wasm/Cargo.toml` - profiles only apply from the workspace root, and the root's existing profile (no `panic=abort`) is correct to leave untouched since `crates/python` needs unwinding panics for PyO3's exception conversion

## Test plan
- [x] `cargo test --workspace --exclude neofoodclub-python --exclude neofoodclub-wasm` passes (198 tests incl. new `test_custom_probabilities_override`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo build -p neofoodclub-wasm --target wasm32-unknown-unknown --release` succeeds
- [x] Verified end-to-end via a nodejs-target wasm-pack build + manual smoke test against a real historical round: all 7 generators produce correct bets/amounts/hashes, invalid input is rejected before reaching Rust's panicking asserts, and both custom-odds and custom-probabilities overrides measurably change the generated output