### PR TITLE
Fix crates/wasm release build: enable nontrapping-float-to-int

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,4 +14,4 @@ serde-wasm-bindgen = "0.6"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O", "--enable-bulk-memory"]
+wasm-opt = ["-O", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]


### PR DESCRIPTION
## Summary
- Real `wasm-pack build --release` (not just `cargo build`, which doesn't run wasm-opt) fails: `i32.trunc_sat_f64_u` (saturating float-to-int, emitted by current rustc for `as u32`/`as usize` casts on f64) isn't allowed by wasm-opt without `--enable-nontrapping-float-to-int`.
- Discovered while wiring the frontend to consume this crate directly instead of its own duplicate wrapper.

## Test plan
- [x] `wasm-pack build crates/wasm --target bundler --release` now succeeds (previously failed at the wasm-opt step)