### PR TITLE
Expose set_custom_probabilities to Python bindings

### DIFF
--- a/crates/python/python/neofoodclub/neofoodclub.pyi
+++ b/crates/python/python/neofoodclub/neofoodclub.pyi
@@ -868,3 +868,17 @@ class NeoFoodClub:
             The modifier to use.
 
         """
+
+    def set_custom_probabilities(
+        self, probabilities: Sequence[Sequence[float]] | None
+    ) -> None:
+        """Overrides the computed win probabilities with caller-supplied values,
+        bypassing the configured probability model entirely. Pass ``None`` to
+        clear the override and resume using the configured probability model.
+
+        Parameters
+        ----------
+        probabilities: Optional[Sequence[Sequence[:class:`float`]]]
+            A 5x5 grid of win probabilities, or ``None`` to clear the override.
+
+        """

--- a/crates/python/src/nfc.rs
+++ b/crates/python/src/nfc.rs
@@ -223,6 +223,10 @@ impl NeoFoodClub {
             .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
+    fn set_custom_probabilities(&mut self, probabilities: Option<[[f64; 5]; 5]>) {
+        self.inner.set_custom_probabilities(probabilities);
+    }
+
     fn max_ters(&self) -> Vec<f64> {
         self.inner.max_ters().clone()
     }

--- a/crates/python/tests/test_neofoodclub.py
+++ b/crates/python/tests/test_neofoodclub.py
@@ -25,6 +25,29 @@ def test_bet_amount(nfc: NeoFoodClub, nfc_from_url: NeoFoodClub) -> None:
     amount(nfc_from_url)
 
 
+def test_set_custom_probabilities(nfc: NeoFoodClub) -> None:
+    new_nfc = nfc.copy()
+    before = new_nfc.make_max_ter_bets()
+
+    # heavily favor arena 0's 4th pirate over everything else, which should
+    # change what max-TER bets get generated versus the default model.
+    probabilities = [
+        [0.0, 0.0, 0.0, 0.0, 1.0],
+        [0.2, 0.2, 0.2, 0.2, 0.2],
+        [0.2, 0.2, 0.2, 0.2, 0.2],
+        [0.2, 0.2, 0.2, 0.2, 0.2],
+        [0.2, 0.2, 0.2, 0.2, 0.2],
+    ]
+    new_nfc.set_custom_probabilities(probabilities)
+    after = new_nfc.make_max_ter_bets()
+    assert before.bets_hash != after.bets_hash
+
+    # clearing the override should restore the original model's output.
+    new_nfc.set_custom_probabilities(None)
+    restored = new_nfc.make_max_ter_bets()
+    assert restored.bets_hash == before.bets_hash
+
+
 def test_modifier(nfc: NeoFoodClub, nfc_from_url: NeoFoodClub) -> None:
     def modify(n: NeoFoodClub) -> None:
         modifier = Modifier(Modifier.REVERSE)


### PR DESCRIPTION
## Summary

PR #178 added a custom-probabilities override to core `NeoFoodClub` (`set_custom_probabilities`) and exposed it through the wasm bindings for the JS/TS frontend, but `crates/python` never got the equivalent - checked, and it's the only gap: everything else PR #178 touched in core/wasm (the pure-math functions, hash codecs) already existed in `crates/python` from before.

Adds `NeoFoodClub.set_custom_probabilities(probabilities: Sequence[Sequence[float]] | None)` to the pyo3 bindings, mirroring the wasm binding's `setCustomProbabilities`/`clearCustomProbabilities` (here unified into one method taking `None` to clear, matching core's own signature).

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean
- [x] `maturin develop` builds and installs the extension
- [x] New test (`test_set_custom_probabilities`) confirms the override changes `make_max_ter_bets()` output and that clearing it (`None`) restores the original model's output
- [x] Full suite: 208/208 pass