### PR TITLE
Expose probabilities getter to Python bindings

### DIFF
--- a/crates/python/python/neofoodclub/neofoodclub.pyi
+++ b/crates/python/python/neofoodclub/neofoodclub.pyi
@@ -845,6 +845,13 @@ class NeoFoodClub:
         """Optional[Dict[:class:`int`, :class:`int`]]: The custom odds of the modifier."""
 
     @property
+    def probabilities(self) -> list[list[float]]:
+        """List[List[:class:`float`]]: The effective 5x5 win-probabilities grid -
+        the override set via :meth:`set_custom_probabilities`, if any, otherwise
+        the configured probability model's computed values.
+        """
+
+    @property
     def pirates(self) -> list[list[int]]:
         """List[List[:class:`int`]]: Returns the pirates in the round."""
 

--- a/crates/python/src/nfc.rs
+++ b/crates/python/src/nfc.rs
@@ -184,6 +184,15 @@ impl NeoFoodClub {
     }
 
     #[getter]
+    fn probabilities(&self) -> Vec<Vec<f64>> {
+        self.inner
+            .probabilities()
+            .into_iter()
+            .map(|p| p.to_vec())
+            .collect()
+    }
+
+    #[getter]
     fn opening_odds(&self) -> Vec<Vec<u8>> {
         self.inner
             .opening_odds()

--- a/crates/python/tests/test_neofoodclub.py
+++ b/crates/python/tests/test_neofoodclub.py
@@ -25,6 +25,17 @@ def test_bet_amount(nfc: NeoFoodClub, nfc_from_url: NeoFoodClub) -> None:
     amount(nfc_from_url)
 
 
+def test_probabilities(nfc: NeoFoodClub) -> None:
+    probabilities = nfc.probabilities
+    assert len(probabilities) == 5
+    for row in probabilities:
+        assert len(row) == 5
+        # index 0 in each arena's row is a fixed placeholder (unused pirate
+        # slot); the 4 real pirate probabilities (indices 1-4) sum to 1.0.
+        assert row[0] == 1.0
+        assert sum(row[1:]) == pytest.approx(1.0)
+
+
 def test_set_custom_probabilities(nfc: NeoFoodClub) -> None:
     new_nfc = nfc.copy()
     before = new_nfc.make_max_ter_bets()
@@ -39,11 +50,15 @@ def test_set_custom_probabilities(nfc: NeoFoodClub) -> None:
         [0.2, 0.2, 0.2, 0.2, 0.2],
     ]
     new_nfc.set_custom_probabilities(probabilities)
+    assert new_nfc.probabilities == probabilities
+
     after = new_nfc.make_max_ter_bets()
     assert before.bets_hash != after.bets_hash
 
     # clearing the override should restore the original model's output.
     new_nfc.set_custom_probabilities(None)
+    assert new_nfc.probabilities == nfc.probabilities
+
     restored = new_nfc.make_max_ter_bets()
     assert restored.bets_hash == before.bets_hash
 


### PR DESCRIPTION
## Summary

Following up on #181: core `NeoFoodClub::probabilities()` (the effective win-probabilities grid - custom override if set via `set_custom_probabilities`, otherwise the configured probability model's computed values) was never exposed to Python. Notable now that #181 landed `set_custom_probabilities` - there was no way to read back what was actually in effect.

Adds a `probabilities` property mirroring the existing `current_odds`/`custom_odds`/`opening_odds` grid-getter pattern.

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean
- [x] New `test_probabilities` confirms grid shape and the index-0-placeholder/sums-to-1 convention (matches core's own `models::original` tests)
- [x] `test_set_custom_probabilities` extended to assert the getter round-trips the override exactly, and reflects the original model's values again after clearing
- [x] Full suite: 209/209 pass