### PR TITLE
ci: run Python test suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,3 +54,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "Build neofoodclub-wasm for wasm32-unknown-unknown"
         run: cargo build -p neofoodclub-wasm --target wasm32-unknown-unknown --release
+
+  python-tests:
+    name: "Python tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: "Install Rust toolchain"
+        run: rustup default nightly
+      - uses: Swatinem/rust-cache@v2
+      - uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+          python-version: "3.11"
+      - name: "Build Python extension"
+        run: cd crates/python && uv run --with maturin maturin develop
+      - name: "Run Python tests"
+        run: cd crates/python && uv run --with pytest pytest tests/


### PR DESCRIPTION
crates/python has a 209-test pytest suite (crates/python/tests/) but no CI workflow ever runs it. CI.yml and test.yml both exclude neofoodclub-python from cargo build/test, and python-wheels.yml builds release wheels for ~10 platforms via maturin without ever testing them. A regression in the PyO3 bindings could ship straight to PyPI with no CI coverage.

Adds a python-tests job to CI.yml that builds the extension with maturin develop and runs pytest tests/, mirroring the local py-test-all workflow in the justfile.

Verified locally: maturin develop builds cleanly and all 209 tests pass.