### PR TITLE
Add real cargo-fuzz setup for hash-parsing functions

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -36,6 +36,13 @@ fix: fmt clippy-fix
 test:
   CARGO_TARGET_DIR=target/nightly RUSTC={{nightly_rustc}} RUSTDOC={{nightly_rustdoc}} {{nightly_cargo}} test --locked
 
+# Fuzzing (crates/core hash-parsing functions) - requires nightly + cargo-fuzz
+fuzz-bets-hash:
+  cd fuzz && cargo +nightly fuzz run fuzz_bets_hash
+
+fuzz-amounts-hash:
+  cd fuzz && cargo +nightly fuzz run fuzz_amounts_hash
+
 # Python bindings (crates/python) - built via maturin, not plain cargo
 py-build:
   cd crates/python && uv run --with maturin maturin develop

--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ This is a Cargo workspace:
 - [Neofood.club](https://neofood.club/)
 - [Neofood.club source](https://github.com/rneopets/neofoodclub)
 - [PyPI package](https://pypi.org/project/neofoodclub/)
+
+## Fuzzing
+
+crates/core has cargo-fuzz targets under `fuzz/` for the untrusted hash-parsing
+functions in `math.rs`. Requires the nightly toolchain and `cargo install cargo-fuzz`.
+
+```
+cargo +nightly fuzz run fuzz_bets_hash
+cargo +nightly fuzz run fuzz_amounts_hash
+```

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+/target
+/corpus
+/artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+[workspace]
+
+[package]
+name = "neofoodclub-core-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+neofoodclub = { path = "../crates/core" }
+
+[[bin]]
+name = "fuzz_bets_hash"
+path = "fuzz_targets/fuzz_bets_hash.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_amounts_hash"
+path = "fuzz_targets/fuzz_amounts_hash.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_amounts_hash.rs
+++ b/fuzz/fuzz_targets/fuzz_amounts_hash.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &str| {
+    let _ = neofoodclub::math::amounts_hash_to_bet_amounts(data);
+});

--- a/fuzz/fuzz_targets/fuzz_bets_hash.rs
+++ b/fuzz/fuzz_targets/fuzz_bets_hash.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &str| {
+    let _ = neofoodclub::math::bets_hash_to_bet_indices(data);
+    let _ = neofoodclub::math::bets_hash_to_bet_binaries(data);
+});


### PR DESCRIPTION
## Summary

- The repo had an untracked `fuzz/` directory (fuzz/artifacts, fuzz/corpus, fuzz/fuzz_targets, fuzz/target) that looked like a working cargo-fuzz setup but had no `fuzz/Cargo.toml` and no actual `.rs` source files, and wasn't tracked by git at all. It gave a false impression that this crate had fuzzing coverage.
- This adds a real, minimal cargo-fuzz setup targeting the untrusted-input hash-parsing functions in `crates/core/src/math.rs` that parse `#b=` and `#a=` URL fragments from neofood.club:
  - `bets_hash_to_bet_indices`
  - `bets_hash_to_bet_binaries`
  - `amounts_hash_to_bet_amounts`
- These already validate input via `bets_hash_check` / `amounts_hash_check` and return `Err(NfcError::...)` on malformed input rather than panicking; the fuzz targets exist to catch any input that manages to slip past that validation and panic instead.
- `fuzz/Cargo.toml` has its own empty `[workspace]` table so it is excluded from the root cargo workspace (standard cargo-fuzz convention); it was not added to the root `Cargo.toml` members list.
- `fuzz/corpus`, `fuzz/artifacts`, `fuzz/target`, and the generated `fuzz/Cargo.lock` are all gitignored and not committed.
- This is not wired into CI. Added a short "Fuzzing" section to README.md and two `just` recipes (`fuzz-bets-hash`, `fuzz-amounts-hash`) for manual use.

## Verification

- Installed `cargo-fuzz` locally (it was already present, version 0.13.2) and ran `cargo +nightly fuzz build` from the repo root - both fuzz targets (`fuzz_bets_hash`, `fuzz_amounts_hash`) build successfully against the real `neofoodclub` crate.
- Note: this version of cargo-fuzz requires a `[package.metadata] cargo-fuzz = true` marker in `fuzz/Cargo.toml`, which is included.
- Ran short smoke runs of both targets (`cargo +nightly fuzz run <target> -- -max_total_time=10 -runs=100000`) - no crashes or panics in either target.
- Ran `cargo fmt --all -- --check` and `cargo clippy --workspace --all-features --locked -- -D warnings` from the repo root - both clean, confirming the README.md/.justfile edits didn't break anything in the main workspace.
- Also ran `cargo clippy -- -D warnings` inside `fuzz/` (its own separate cargo workspace) - clean.