### PR TITLE
ci: add scheduled fuzzing workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,36 @@
+name: Fuzz
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    name: "Fuzz ${{ matrix.target }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [fuzz_bets_hash, fuzz_amounts_hash]
+    steps:
+      - uses: actions/checkout@v7
+      - name: "Install Rust toolchain"
+        run: rustup default nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz -> target
+      - name: "Install cargo-fuzz"
+        run: cargo install cargo-fuzz --locked
+      - name: "Run ${{ matrix.target }} for 5 minutes"
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=300
+      - name: "Upload crash artifacts"
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}


### PR DESCRIPTION
Depends on #189 (adds the fuzz/ setup this workflow runs).

Fuzzing is open-ended rather than pass/fail, so it doesn't fit as a per-PR CI gate: either the time budget is short enough to keep CI fast, in which case it barely exercises anything, or long enough to be useful, in which case it slows down every PR. Instead this adds a weekly (Sunday 00:00 UTC) scheduled workflow that runs each fuzz target (fuzz_bets_hash, fuzz_amounts_hash) for 5 minutes via cargo-fuzz, uploading the crash artifact as a build artifact if one is found. Also runnable on demand via workflow_dispatch.

Verified locally: ran both targets with cargo fuzz run <target> -- -max_total_time=15, no crashes, matching the command the workflow uses (just with a longer budget).