### PR TITLE
test: add coverage for neofoodclub-wasm

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "Build neofoodclub-wasm for wasm32-unknown-unknown"
         run: cargo build -p neofoodclub-wasm --target wasm32-unknown-unknown --release
+      - name: "Run neofoodclub-wasm host-target unit tests"
+        run: cargo test -p neofoodclub-wasm
+      - uses: taiki-e/install-action@wasm-pack
+      - name: "Run neofoodclub-wasm wasm-bindgen-test suite"
+        working-directory: crates/wasm
+        run: wasm-pack test --node
 
   python-tests:
     name: "Python tests"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +69,12 @@ name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -411,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +444,16 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "neofoodclub"
@@ -459,6 +492,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -474,12 +508,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -487,6 +531,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "percent-encoding"
@@ -700,6 +750,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +948,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +968,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -931,6 +1010,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -13,5 +13,8 @@ serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-O", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]

--- a/crates/wasm/src/hash.rs
+++ b/crates/wasm/src/hash.rs
@@ -51,3 +51,69 @@ pub fn compute_bet_amounts_to_amounts_hash(amounts: Vec<i64>) -> String {
         .collect();
     math::bet_amounts_to_amounts_hash(&opts)
 }
+
+// Note: only the Ok path of these Result<_, JsError>-returning functions is
+// safe to exercise here. Constructing a JsError (the Err path) calls into
+// wasm-bindgen's JS glue and panics on non-wasm targets with "cannot call
+// wasm-bindgen imported functions on non-wasm targets" - so error-path
+// coverage for these functions lives in crates/wasm/tests/web.rs instead,
+// run via wasm-pack test --node.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bets_hash_to_indices_decodes_valid_hash() {
+        let indices = compute_bets_hash_to_indices("faafaafaafaafaafaa").unwrap();
+        assert_eq!(
+            indices,
+            vec![
+                1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+                0, 0
+            ]
+        );
+    }
+
+    #[test]
+    fn bets_indices_to_hash_round_trips() {
+        let flat = compute_bets_hash_to_indices("faa").unwrap();
+        let hash = compute_bets_indices_to_hash(flat.clone()).unwrap();
+        let round_tripped = compute_bets_hash_to_indices(&hash).unwrap();
+        assert_eq!(round_tripped, flat);
+    }
+
+    #[test]
+    fn amounts_hash_to_bet_amounts_decodes_valid_hash() {
+        let amounts = compute_amounts_hash_to_bet_amounts("AaYAbWAcUAdSAeQ").unwrap();
+        assert_eq!(amounts, vec![50, 100, 150, 200, 250]);
+    }
+
+    #[test]
+    fn amounts_hash_to_bet_amounts_uses_negative_one_sentinel_for_unset() {
+        // The 10th amount in this hash decodes to None (below BET_AMOUNT_MIN).
+        let amounts =
+            compute_amounts_hash_to_bet_amounts("EmxCoKCoKCglDKUCYqEXkByWBpqzGO").unwrap();
+        assert_eq!(amounts.last(), Some(&-1));
+        assert!(amounts[..9].iter().all(|&v| v >= 1));
+    }
+
+    #[test]
+    fn bet_amounts_to_amounts_hash_round_trips() {
+        let amounts = vec![50, 100, 150, 200, 250];
+        let hash = compute_bet_amounts_to_amounts_hash(amounts.clone());
+        let round_tripped = compute_amounts_hash_to_bet_amounts(&hash).unwrap();
+        assert_eq!(round_tripped, amounts);
+    }
+
+    #[test]
+    fn bet_amounts_to_amounts_hash_encodes_values_below_one_as_unset() {
+        // 0 and the -1 sentinel should both encode as "unset".
+        let hash_zero = compute_bet_amounts_to_amounts_hash(vec![0]);
+        let hash_sentinel = compute_bet_amounts_to_amounts_hash(vec![-1]);
+        assert_eq!(hash_zero, hash_sentinel);
+        assert_eq!(
+            compute_amounts_hash_to_bet_amounts(&hash_zero).unwrap(),
+            vec![-1]
+        );
+    }
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -143,3 +143,58 @@ pub fn compute_pirates_binary(pirates: Vec<u8>) -> Result<u32, JsError> {
 pub fn compute_binary_to_pirates(bin: u32) -> Vec<u8> {
     math::binary_to_indices(bin).to_vec()
 }
+
+// Note: only the Ok path of these Result<_, JsError>-returning functions is
+// safe to exercise here. Constructing a JsError (the Err path) calls into
+// wasm-bindgen's JS glue and panics on non-wasm targets with "cannot call
+// wasm-bindgen imported functions on non-wasm targets" - so error-path
+// coverage for these functions (and anything returning JsValue) lives in
+// crates/wasm/tests/web.rs instead, run via wasm-pack test --node.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ROUND_DATA_JSON: &str = r#"
+{"foods":[[5,20,24,21,18,7,34,29,38,8],[26,24,20,36,33,40,5,13,8,25],[5,29,22,31,40,27,30,4,8,19],[35,19,36,5,12,37,6,3,29,30],[28,24,36,17,18,9,1,33,19,3]],"round":8765,"start":"2023-05-05T23:14:57+00:00","changes":[{"t":"2023-05-06T00:17:30+00:00","new":7,"old":5,"arena":1,"pirate":3},{"t":"2023-05-06T00:21:43+00:00","new":10,"old":8,"arena":3,"pirate":2}],"pirates":[[6,11,4,3],[14,15,2,9],[10,16,18,20],[1,12,13,5],[8,19,17,7]],"winners":[3,2,3,2,2],"timestamp":"2023-05-06T23:14:20+00:00","lastChange":"2023-05-06T19:21:01+00:00","currentOdds":[[1,11,3,2,3],[1,13,2,7,13],[1,13,2,4,2],[1,2,10,6,6],[1,13,4,2,4]],"openingOdds":[[1,11,3,2,4],[1,13,2,5,13],[1,13,2,5,2],[1,2,8,5,5],[1,13,3,2,4]]}
+"#;
+
+    #[test]
+    fn compute_std_probabilities_returns_25_elements_for_original_model() {
+        let probs = compute_std_probabilities(ROUND_DATA_JSON, false).unwrap();
+        assert_eq!(probs.len(), 25);
+    }
+
+    #[test]
+    fn compute_std_probabilities_returns_25_elements_for_logit_model() {
+        let probs = compute_std_probabilities(ROUND_DATA_JSON, true).unwrap();
+        assert_eq!(probs.len(), 25);
+    }
+
+    #[test]
+    fn compute_arena_ratios_happy_path() {
+        let odds = vec![
+            1.0, 11.0, 3.0, 2.0, 3.0, 1.0, 13.0, 2.0, 7.0, 13.0, 1.0, 13.0, 2.0, 4.0, 2.0, 1.0,
+            2.0, 10.0, 6.0, 6.0, 1.0, 13.0, 4.0, 2.0, 4.0,
+        ];
+        let ratios = compute_arena_ratios(odds).unwrap();
+        assert_eq!(ratios.len(), 5);
+    }
+
+    #[test]
+    fn compute_pirate_binary_matches_underlying_math_fn() {
+        assert_eq!(compute_pirate_binary(0, 1), math::pirate_binary(1, 0));
+    }
+
+    #[test]
+    fn compute_pirates_binary_happy_path() {
+        let bin = compute_pirates_binary(vec![1, 2, 3, 4, 1]).unwrap();
+        assert_eq!(bin, math::pirates_binary([1, 2, 3, 4, 1]));
+    }
+
+    #[test]
+    fn compute_binary_to_pirates_round_trips_with_pirates_binary() {
+        let indices = vec![1, 2, 3, 4, 1];
+        let bin = compute_pirates_binary(indices.clone()).unwrap();
+        assert_eq!(compute_binary_to_pirates(bin), indices);
+    }
+}

--- a/crates/wasm/tests/web.rs
+++ b/crates/wasm/tests/web.rs
@@ -1,0 +1,145 @@
+//! Tests for the functions in this crate that return `JsValue` or hit the
+//! `JsError` `Err` path. Those two things call into wasm-bindgen's JS glue,
+//! which panics on non-wasm targets - so unlike the plain `#[test]`s in
+//! `src/hash.rs` and `src/lib.rs`, these must run under `wasm-pack test --node`.
+
+use neofoodclub_wasm::*;
+use serde::Deserialize;
+use wasm_bindgen_test::*;
+
+const ROUND_DATA_JSON: &str = r#"
+{"foods":[[5,20,24,21,18,7,34,29,38,8],[26,24,20,36,33,40,5,13,8,25],[5,29,22,31,40,27,30,4,8,19],[35,19,36,5,12,37,6,3,29,30],[28,24,36,17,18,9,1,33,19,3]],"round":8765,"start":"2023-05-05T23:14:57+00:00","changes":[{"t":"2023-05-06T00:17:30+00:00","new":7,"old":5,"arena":1,"pirate":3},{"t":"2023-05-06T00:21:43+00:00","new":10,"old":8,"arena":3,"pirate":2}],"pirates":[[6,11,4,3],[14,15,2,9],[10,16,18,20],[1,12,13,5],[8,19,17,7]],"winners":[3,2,3,2,2],"timestamp":"2023-05-06T23:14:20+00:00","lastChange":"2023-05-06T19:21:01+00:00","currentOdds":[[1,11,3,2,3],[1,13,2,7,13],[1,13,2,4,2],[1,2,10,6,6],[1,13,4,2,4]],"openingOdds":[[1,11,3,2,4],[1,13,2,5,13],[1,13,2,5,2],[1,2,8,5,5],[1,13,3,2,4]]}
+"#;
+
+#[derive(Deserialize)]
+struct ChanceOutTest {
+    #[allow(dead_code)]
+    value: u32,
+    probability: f64,
+    cumulative: f64,
+    tail: f64,
+}
+
+#[derive(Deserialize)]
+struct PayoutTablesOutTest {
+    odds: Vec<ChanceOutTest>,
+    winnings: Vec<ChanceOutTest>,
+}
+
+#[derive(Deserialize)]
+struct BetsOutTest {
+    indices: Vec<[u8; 5]>,
+    #[allow(dead_code)]
+    amounts: Option<Vec<Option<u32>>>,
+    #[serde(rename = "betsHash")]
+    bets_hash: String,
+    #[allow(dead_code)]
+    #[serde(rename = "amountsHash")]
+    amounts_hash: Option<String>,
+}
+
+fn assert_chances_well_formed(chances: &[ChanceOutTest]) {
+    assert!(!chances.is_empty());
+    // Each entry's `tail` is the running "probability not yet accounted for"
+    // *before* that entry's own probability is subtracted off, so the first
+    // entry always starts at 1.0 and cumulative/tail move monotonically.
+    assert!((chances[0].tail - 1.0).abs() < 1e-9);
+    let mut prev_cumulative = 0.0;
+    let mut prev_tail = 1.0;
+    for chance in chances {
+        assert!((chance.cumulative - (prev_cumulative + chance.probability)).abs() < 1e-9);
+        assert!(chance.tail <= prev_tail + 1e-9);
+        prev_cumulative = chance.cumulative;
+        prev_tail = chance.tail;
+    }
+}
+
+#[wasm_bindgen_test]
+fn compute_payout_tables_returns_well_formed_tables() {
+    let bet_indices = vec![1, 0, 0, 0, 0];
+    let probabilities = vec![0.1; 25];
+    let bet_odds = vec![13];
+    let bet_payoffs = vec![1300];
+
+    let result = compute_payout_tables(bet_indices, probabilities, bet_odds, bet_payoffs).unwrap();
+    let parsed: PayoutTablesOutTest = serde_wasm_bindgen::from_value(result).unwrap();
+
+    assert_chances_well_formed(&parsed.odds);
+    assert_chances_well_formed(&parsed.winnings);
+}
+
+#[wasm_bindgen_test]
+fn compute_payout_tables_rejects_bad_bet_indices_length() {
+    let result = compute_payout_tables(vec![1, 0, 0, 0], vec![0.1; 25], vec![13], vec![1300]);
+    assert!(result.is_err());
+}
+
+#[wasm_bindgen_test]
+fn compute_payout_tables_rejects_mismatched_odds_payoffs_length() {
+    let result =
+        compute_payout_tables(vec![1, 0, 0, 0, 0], vec![0.1; 25], vec![13, 20], vec![1300]);
+    assert!(result.is_err());
+}
+
+#[wasm_bindgen_test]
+fn compute_payout_tables_rejects_wrong_probabilities_length() {
+    let result = compute_payout_tables(vec![1, 0, 0, 0, 0], vec![0.1; 24], vec![13], vec![1300]);
+    assert!(result.is_err());
+}
+
+#[wasm_bindgen_test]
+fn compute_bets_hash_to_indices_rejects_malformed_hash() {
+    // 'z' is outside the valid a-y range.
+    assert!(compute_bets_hash_to_indices("zzz").is_err());
+}
+
+#[wasm_bindgen_test]
+fn compute_bets_indices_to_hash_rejects_bad_length() {
+    assert!(compute_bets_indices_to_hash(vec![1, 0, 0, 0]).is_err());
+}
+
+#[wasm_bindgen_test]
+fn compute_arena_ratios_rejects_wrong_length() {
+    assert!(compute_arena_ratios(vec![1.0; 24]).is_err());
+}
+
+#[wasm_bindgen_test]
+fn compute_pirates_binary_rejects_wrong_length() {
+    assert!(compute_pirates_binary(vec![1, 2, 3]).is_err());
+}
+
+#[wasm_bindgen_test]
+fn compute_std_probabilities_rejects_invalid_json() {
+    assert!(compute_std_probabilities("not json", false).is_err());
+}
+
+#[wasm_bindgen_test]
+fn nfc_engine_full_flow() {
+    let mut engine = NfcEngine::new(ROUND_DATA_JSON, Some(8000), false).unwrap();
+
+    engine.set_bet_amount(Some(5000));
+
+    // 25-element flattened odds grid (5 arenas x [unused, o1..o4]).
+    let odds_grid: Vec<u8> = vec![
+        0, 11, 3, 2, 3, 0, 13, 2, 7, 13, 0, 13, 2, 4, 2, 0, 2, 10, 6, 6, 0, 13, 4, 2, 4,
+    ];
+    engine.set_custom_odds(odds_grid).unwrap();
+    engine.clear_custom_odds().unwrap();
+
+    let probs_grid: Vec<f64> = vec![0.2; 25];
+    engine.set_custom_probabilities(probs_grid).unwrap();
+    engine.clear_custom_probabilities();
+
+    let result = engine.make_max_ter_bets().unwrap();
+    let parsed: BetsOutTest = serde_wasm_bindgen::from_value(result).unwrap();
+    assert!(!parsed.indices.is_empty());
+    assert!(!parsed.bets_hash.is_empty());
+}
+
+#[wasm_bindgen_test]
+fn nfc_engine_make_gambit_bets_rejects_wrong_pirate_count() {
+    let engine = NfcEngine::new(ROUND_DATA_JSON, Some(8000), false).unwrap();
+    // Selects only one pirate total instead of exactly 5 (one per arena).
+    let single_pick = 1u32;
+    assert!(engine.make_gambit_bets(single_pick).is_err());
+}


### PR DESCRIPTION
neofoodclub-wasm had zero tests; CI only checked that it builds for wasm32-unknown-unknown. A regression in the crate's argument validation, hash round-tripping, or NfcEngine wrapper logic could ship with no coverage.

Adds two tiers, based on a runtime discovery: functions in this crate that return plain Rust types (Vec, String, u32, etc.) run fine as normal #[test]s on the host target, but anything that returns JsValue or constructs a JsError (the Err path of a Result<_, JsError>) panics on non-wasm targets with "cannot call wasm-bindgen imported functions on non-wasm targets", since both call into wasm-bindgen's JS glue.

- src/hash.rs and src/lib.rs: plain #[test]s covering the Ok path of every exported function (hash round-tripping, arena ratios, pirate binary conversions, probability computation).
- tests/web.rs: a wasm-bindgen-test suite (run via wasm-pack test --node) covering the Err paths and everything that returns JsValue (compute_payout_tables, all of NfcEngine).
- Wires both into the existing wasm-build CI job: cargo test -p neofoodclub-wasm for the host tier, wasm-pack test --node for the wasm tier.

Verified locally: cargo test -p neofoodclub-wasm (12 passed), wasm-pack test --node (11 passed), cargo build -p neofoodclub-wasm --target wasm32-unknown-unknown --release still succeeds, clippy clean on both host and wasm32 targets, fmt clean.