### PR TITLE
Fix update-logit-values workflow push and setup-uv warning

### DIFF
--- a/.github/workflows/update-logit-values.yml
+++ b/.github/workflows/update-logit-values.yml
@@ -17,12 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.ADMIN_PUSH_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: false
-          python-version-file: automation/.python-version
+          working-directory: automation
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- The monthly retrain job pushed straight to main with the default GITHUB_TOKEN, which branch protection always rejects (GH006) since a bare push can never satisfy the 5 required status checks. Checkout now authenticates with the ADMIN_PUSH_TOKEN secret (an admin PAT), whose pushes are allowed to bypass required checks per this repo's branch protection settings.
- Fixes a setup-uv v9.0.0 warning: python-version-file was removed as an input; working-directory: automation gets the same auto-discovery of automation/.python-version.

Related failing run: https://github.com/rneopets/neofoodclub.rs/actions/runs/30681740547/job/91320003087