### PR TITLE
Stop asserting exact bet identities in the logit model test

### DIFF
--- a/crates/python/tests/test_model_logit.py
+++ b/crates/python/tests/test_model_logit.py
@@ -6,16 +6,8 @@ def test_mer_bets_With_bet_amouunt(
 ) -> None:
     bets = nfc_with_bet_amount_logit_model.make_max_ter_bets()
 
-    # this may break if the logit data changes!
-    assert set(bets.binaries) == {
-        0x408,
-        0x88008,
-        0x82008,
-        0x80408,
-        0x88108,
-        0x80008,
-        0x82108,
-        0x80108,
-        0x80018,
-        0x80118,
-    }
+    # the exact bet identities depend on the trained logit coefficients,
+    # which are retrained monthly, so only assert on properties that don't
+    # change when the coefficients do
+    assert len(bets.binaries) == 10
+    assert len(set(bets.binaries)) == 10


### PR DESCRIPTION
## Summary
- test_mer_bets_With_bet_amouunt hardcoded the exact winning bet set from the multinomial logit model, but those coefficients are retrained and pushed to main every month by update-logit-values.yml. That makes the test break on every coefficient drift, which is what happened after the most recent retrain (main is currently red).
- Replaced the exact-value assertion with coefficient-independent invariants (bet count, uniqueness), matching how the equivalent Rust test (test_logit in integration_test.rs) already only checks structural properties.

Related failing run: https://github.com/rneopets/neofoodclub.rs/actions/runs/30869308193/job/91867801710